### PR TITLE
overlay continues if it gets extraneous parameters

### DIFF
--- a/its/tests/test_overlay.py
+++ b/its/tests/test_overlay.py
@@ -10,6 +10,12 @@ class TestOverlay(TestCase):
         app.config["TESTING"] = True
         self.client = app.test_client()
 
+    def test_simple_overlay(self):
+        response = self.client.get(
+            "tests/images/test.png?overlay=tests/images/five.png"
+        )
+        assert response.status_code == 200
+
     def test_legacy_passport_resize_overlay(self):
         response = self.client.get(
             "tests/images/test.png.resize.1000x1000.passport.png"

--- a/its/transformations/overlay.py
+++ b/its/transformations/overlay.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from PIL import Image
@@ -6,6 +7,8 @@ from ..errors import ConfigError, ITSTransformError
 from ..loaders import BaseLoader
 from ..settings import NAMESPACES, OVERLAYS
 from .base import BaseTransform
+
+LOGGER = logging.getLogger(__name__)
 
 OVERLAY_PROPORTION = 0.2
 
@@ -22,7 +25,9 @@ class OverlayTransform(BaseTransform):
 
     def apply_transform(img, parameters):
         if len(parameters) > 1:
-            raise ValueError("overlay transform does not accept parameters")
+            LOGGER.error(
+                "overlay transform does not accept parameters, received %s", parameters
+            )
 
         overlay = parameters[0]
 


### PR DESCRIPTION
in production, we've observed strange cases where using a url like https://image.pbs.org/test/QdTpmRS-asset-mezzanine-16x9-zaTWonY.png\?overlay\=test/rose-1385970_960_720.png fails, with this ValueError.

It's not clear what the server's receiving, so we're adding logging here (for further investigation) and telling the overlay transform to continue (to fix the immediate bug).

Adding a basic test too, but it passes before this change too.