### PR TITLE
normalize custom overlay parameter to remove leading/trailing slashes

### DIFF
--- a/its/tests/test_overlay.py
+++ b/its/tests/test_overlay.py
@@ -16,6 +16,12 @@ class TestOverlay(TestCase):
         )
         assert response.status_code == 200
 
+    def test_overlay_with_leading_slash(self):
+        response = self.client.get(
+            "tests/images/test.png?overlay=/tests/images/five.png"
+        )
+        assert response.status_code == 200
+
     def test_simple_overlay_with_underscores(self):
         response = self.client.get(
             "tests/images/test.png?overlay=tests/images/five-something_with_underscores.png"

--- a/its/transformations/overlay.py
+++ b/its/transformations/overlay.py
@@ -46,7 +46,7 @@ class OverlayTransform(BaseTransform):
             raise ConfigError("No Backend has been set up for overlays.")
 
         if overlay.lower() not in OVERLAYS:
-            namespace, *filename = overlay.split("/")
+            namespace, *filename = overlay.strip("/").split("/")
             filename = Path("/".join(filename))
             overlay_image = loader[0].load_image(namespace, filename)
         else:


### PR DESCRIPTION
the enclosed test passes before the application change too; but I think this change will fix this error https://image.pbs.org/test/QdTpmRS-asset-mezzanine-16x9-zaTWonY.png?overlay=/test/rose-1385970_960_720.png

it's tricky to test the s3 loader directly...