### PR TITLE
newrelic: ignore werkzeug.exceptions:BadRequest exceptions

### DIFF
--- a/etc/confd/templates/newrelic.ini.tmpl
+++ b/etc/confd/templates/newrelic.ini.tmpl
@@ -154,7 +154,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors = its.errors:ITSClientError
+error_collector.ignore_errors = its.errors:ITSClientError werkzeug.exceptions:BadRequest
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this


### PR DESCRIPTION
by default, newrelic considers all "unhandled" python exceptions application errors. however, `werkzeug.exceptions:BadRequest` exceptions are thrown by flask when we use the `abort` handler, as we do, for example, if a bad namespace is used:

```python
    if namespace not in NAMESPACES:
        abort(
            400, "{namespace} is not a configured namespace".format(namespace=namespace)
        )
```

we can safely ignore these errors in monitoring like newrelic, they are noise rather than signal.