### PR TITLE
bugfix: ensure focalcrop parity

### DIFF
--- a/its/application.py
+++ b/its/application.py
@@ -14,7 +14,7 @@ from its.optimize import optimize
 from its.pipeline import process_transforms
 from its.settings import MIME_TYPES
 
-from .settings import NAMESPACES, SENTRY_DSN
+from .settings import FIT_SYNONYMS, NAMESPACES, SENTRY_DSN
 from .util import get_redirect_location
 
 # https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images
@@ -28,6 +28,11 @@ if SENTRY_DSN:
 
 
 def process_request(namespace: str, query: Dict[str, str], filename: str) -> Response:
+    for fit_snynonym in FIT_SYNONYMS:
+        if fit_snynonym in query:
+            query["fit"] = query[fit_snynonym]
+            del query[fit_snynonym]
+
     if namespace not in NAMESPACES:
         abort(
             400, "{namespace} is not a configured namespace".format(namespace=namespace)
@@ -79,7 +84,7 @@ def process_old_request(
 
     query = {}
 
-    if transform in ["focalcrop", "crop", "fit"]:
+    if transform in FIT_SYNONYMS:
         transform = "fit"
 
     query[transform] = "x"

--- a/its/application.py
+++ b/its/application.py
@@ -28,6 +28,9 @@ if SENTRY_DSN:
 
 
 def process_request(namespace: str, query: Dict[str, str], filename: str) -> Response:
+    if len((set(FIT_SYNONYMS) | set(["fit"])) & set(query.keys())) > 1:
+        raise ITSClientError("use only one of these synonyms: fit, crop, focalcrop")
+
     for fit_snynonym in FIT_SYNONYMS:
         if fit_snynonym in query:
             query["fit"] = query[fit_snynonym]

--- a/its/application.py
+++ b/its/application.py
@@ -14,7 +14,7 @@ from its.optimize import optimize
 from its.pipeline import process_transforms
 from its.settings import MIME_TYPES
 
-from .settings import FIT_SYNONYMS, NAMESPACES, SENTRY_DSN
+from .settings import NAMESPACES, SENTRY_DSN
 from .util import get_redirect_location
 
 # https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images
@@ -28,10 +28,11 @@ if SENTRY_DSN:
 
 
 def process_request(namespace: str, query: Dict[str, str], filename: str) -> Response:
-    if len((set(FIT_SYNONYMS) | set(["fit"])) & set(query.keys())) > 1:
+    fit_synonyms = {"crop", "focalcrop"}
+    if len((fit_synonyms | {"fit"}) & set(query.keys())) > 1:
         raise ITSClientError("use only one of these synonyms: fit, crop, focalcrop")
 
-    for fit_snynonym in FIT_SYNONYMS:
+    for fit_snynonym in fit_synonyms:
         if fit_snynonym in query:
             query["fit"] = query[fit_snynonym]
             del query[fit_snynonym]

--- a/its/application.py
+++ b/its/application.py
@@ -86,11 +86,8 @@ def process_old_request(
 ) -> Dict[str, str]:
 
     query = {}
-
-    if transform in FIT_SYNONYMS:
-        transform = "fit"
-
     query[transform] = "x"
+
     if width is not None:
         query[transform] = str(width) + query[transform]
 

--- a/its/settings.py
+++ b/its/settings.py
@@ -53,5 +53,3 @@ FOCUS_KEYWORD = os.environ.get("ITS_FOCUS_KEYWORD", "focus-")
 DELIMITERS_RE = os.environ.get("ITS_DELIMITERS_RE", "[x_,]")
 
 SENTRY_DSN = os.environ.get("ITS_SENTRY_DSN")
-
-FIT_SYNONYMS = ["crop", "focalcrop"]

--- a/its/settings.py
+++ b/its/settings.py
@@ -53,3 +53,5 @@ FOCUS_KEYWORD = os.environ.get("ITS_FOCUS_KEYWORD", "focus-")
 DELIMITERS_RE = os.environ.get("ITS_DELIMITERS_RE", "[x_,]")
 
 SENTRY_DSN = os.environ.get("ITS_SENTRY_DSN")
+
+FIT_SYNONYMS = ["crop", "focalcrop"]

--- a/its/tests/test_client_error_handling.py
+++ b/its/tests/test_client_error_handling.py
@@ -15,6 +15,14 @@ class TestClientErrorHandling(TestCase):
         assert response.status_code == 400
         assert "invalid-namespace is not a configured namespace" in body
 
+    def test_fit_synonyms(self):
+        response = self.client.get("tests/images/test.jpeg?fit=10x10&crop=20x20")
+        assert response.status_code == 400
+        assert (
+            "use only one of these synonyms: fit, crop, focalcrop"
+            in response.data.decode("utf-8")
+        )
+
     def test_non_image_file(self):
         response = self.client.get("/tests/images/not-an-image.jpg")
         body = response.data.decode("utf-8")

--- a/its/tests/test_pipeline.py
+++ b/its/tests/test_pipeline.py
@@ -33,13 +33,6 @@ def compare_pixels(img1, img2):
     for pixel_pair in zip(img1_pixels, img2_pixels):
         if pixel_pair[0] == pixel_pair[1]:
             matches += 1
-        else:
-            r1, g1, *b1 = pixel_pair[0]
-            r2, g2, *b2 = pixel_pair[1]
-            test = "%d %d %d vs %d %d %d" % (r1, g1, b1[0], r2, g2, b2[0])
-            print(test)
-            diff = "%d %d %d" % (abs(r1 - r2), abs(g1 - g2), abs(b1[0] - b2[0]))
-            print(diff)
 
     return matches / total
 
@@ -360,6 +353,19 @@ class TestPipelineEndToEnd(TestCase):
         response = self.client.get("tests/images/seagull?format=auto")
         assert response.status_code == 200
         assert response.mimetype == "image/jpeg"
+
+    def test_focalcrop_parity(self):
+        old_style_response = self.client.get(
+            "tests/images/test.png.focalcrop.767x421.50.10.png"
+        )
+        new_style_response = self.client.get(
+            "tests/images/test.png?focalcrop=767x421x50x10&format=png"
+        )
+        comparison = compare_pixels(
+            Image.open(BytesIO(old_style_response.data)),
+            Image.open(BytesIO(new_style_response.data)),
+        )
+        self.assertGreaterEqual(comparison, self.threshold)
 
 
 if __name__ == "__main__":

--- a/its/transformations/fit.py
+++ b/its/transformations/fit.py
@@ -45,7 +45,6 @@ class FitTransform(BaseTransform):
         focal crop : image.png?crop=WWxHHxFXxFY
         smart crop : image_focus-FXxFY.png?crop=WWxHH
         """
-
         crop_width, crop_height, *focal_point = parameters
         filename = img.info["filename"]
         # match everything before and including the keyword


### PR DESCRIPTION
currently, these two urls give different results:

- https://image.pbs.org/video-assets/si3MGlW-asset-mezzanine-16x9-9nIAFQI.jpg?focalcrop=767x421x50x10&format=jpg
- https://image.pbs.org/video-assets/si3MGlW-asset-mezzanine-16x9-9nIAFQI.jpg.focalcrop.767x421.50.10.jpg

this PR should fix that, and adds a regression test