### PR TITLE
OCTO-9205: ensure that s3 keys never have leading slashes

### DIFF
--- a/its/loaders/s3_loader.py
+++ b/its/loaders/s3_loader.py
@@ -29,7 +29,7 @@ class S3Loader(BaseLoader):
 
         config = NAMESPACES[namespace]
         path = config.get("path", namespace).strip("/")
-        key = "{path}/{filename}".format(path=path, filename=filename)
+        key = "{path}/{filename}".format(path=path, filename=filename).strip("/")
         bucket_name = config[S3Loader.parameter_name]
         s3_object = s3_resource.Object(bucket_name=bucket_name, key=key)
 


### PR DESCRIPTION
if we have an ITS namespace using the s3 loader, and we want to mirror the entire bucket rather than a prefix, we use config like this:

```json
        "namespace-name": {
            "loader": "s3",
            "bucket": "bucket-name",
            "path": "/"
        }
```
Because that path gets turned into an empty string internally, if we try to get its.example.com/namespace-name/nested/thing.png, our s3 logic tries to get the key `/namespace-name/nested/thing.png`, instead of the correct `namespace-name/nested/thing.png`

This patch fixes that :)