### PR TITLE
OCTO-9254: serve progressive jpegs

### DIFF
--- a/its/application.py
+++ b/its/application.py
@@ -95,7 +95,12 @@ def process_request(namespace: str, query: Dict[str, str], filename: str) -> Res
 
         output = BytesIO()
 
-        result.save(output, format=result.format.upper())
+        if result.format.upper() in ("JPEG", "JPG"):
+            result.save(
+                output, format=result.format.upper(), progressive=True, optimize=True
+            )
+        else:
+            result.save(output, format=result.format.upper())
 
     # our images are cacheable for one year
     # NOTE this would be the right place to do clever things like:

--- a/its/tests/test_pipeline.py
+++ b/its/tests/test_pipeline.py
@@ -467,6 +467,24 @@ class TestPipelineEndToEnd(TestCase):
         image = Image.open(BytesIO(response.data))
         assert "icc_profile" not in image.info
 
+    def test_progressive_jpeg(self):
+        # thanks to http://techslides.com/detecting-progressive-jpeg for this method
+        def is_progressive(buffer):
+            prog_jpeg_header_marker = b"\xff\xc2"
+            prog_jpeg_scan_start_marker = b"\xff\xda"
+            buffer.seek(0)
+            content = buffer.read()
+            if not content.find(prog_jpeg_header_marker):
+                return False
+            if content.count(prog_jpeg_scan_start_marker) < 2:
+                return False
+            return True
+
+        response = self.client.get("tests/images/seagull.jpg")
+        assert response.mimetype == "image/jpeg"
+        buffer = BytesIO(response.data)
+        assert is_progressive(buffer)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When serving images from ITS, we use PIL Image types internally, saving them to a `BytesIO` object for binary transfer over the HTTP response.

This patch ensures that we use the `progressive=True` flag for this save, for jpeg images, so that clients receive progressive jpegs. (we used this flag previously internally elsewhere, but not on the last save before sending the response, so we were turning our progressive jpegs into non-progressive jpegs right at the end).

http://techslides.com/detecting-progressive-jpeg provides a useful method for detecting if a jpeg is progressive or not, adapting that here for a unit test.