### PR TITLE
Feature/resize no scale up

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Where:
 - WW -- a numerical pixel value representing the desired width of the output image
 - HH -- a numerical pixel value representing the desired height of the output image
 
+Resize has an option to not scale up, if the provided width and/or height is larger than those of the image. Use the `resize` keyword, but add **a comma and a third** argument `no-scale-up`:
+
+> https://image.pbs.org/path/to/file.jpg?resize=WWxHH,no-scale-up
+
+Or, with missing height:
+> https://image.pbs.org/path/to/file.jpg?resize=WWx,no-scale-up
+
+Or, with missing width:
+> https://image.pbs.org/path/to/file.jpg?resize=xHH,no-scale-up
+
 Note: Resizing to a larger size isn’t recommended, as it will compromise image quality.
 
 Note: Inputing a single value (either an expected width size or an expected height size followed by an 'x') is also supported.

--- a/its/tests/test_pipeline.py
+++ b/its/tests/test_pipeline.py
@@ -230,12 +230,58 @@ class TestResizeTransform(TestCase):
         comparison = compare_pixels(expected, actual)
         self.assertGreaterEqual(comparison, self.threshold)
 
+    def test_resize_integrity_smaller_noscaleup(self):
+        test_image = Image.open(self.img_dir / "test.png")
+        test_image.info["filename"] = "test.png"
+        query = {"resize": "100x100,no-scale-up"}
+        expected = Image.open(self.img_dir / "expected/test_resize.png")
+        actual = process_transforms(test_image, query)
+        # no-scale-up doesn't change
+        assert actual.width == expected.width
+        assert actual.height == expected.height
+        comparison = compare_pixels(expected, actual)
+        self.assertGreaterEqual(comparison, self.threshold)
+
     def test_resize_integrity_larger(self):
         test_image = Image.open(self.img_dir / "test.png")
         test_image.info["filename"] = "test.png"
         query = {"resize": "700x550"}
         expected = Image.open(self.img_dir / "expected/test_resize_700x550.png")
         actual = process_transforms(test_image, query)
+        comparison = compare_pixels(expected, actual)
+        self.assertGreaterEqual(comparison, self.threshold)
+
+    def test_resize_integrity_larger_noscaleup(self):
+        test_image = Image.open(self.img_dir / "logo.png")
+        test_image.info["filename"] = "logo.png"
+        query = {"resize": "700x700,no-scale-up"}
+        # image doesn't scale up, so expect no change
+        expected = Image.open(self.img_dir / "logo.png")
+        actual = process_transforms(test_image, query)
+        comparison = compare_pixels(expected, actual)
+        assert actual.width == expected.width
+        assert actual.height == expected.height
+        self.assertGreaterEqual(comparison, self.threshold)
+
+    def test_resize_integrity_larger_noscaleup_width_only(self):
+        test_image = Image.open(self.img_dir / "seagull.jpg")
+        test_image.info["filename"] = "seagull.jpg"
+        query = {"resize": "1600x,no-scale-up"}
+        expected = Image.open(self.img_dir / "seagull.jpg")
+        actual = process_transforms(test_image, query)
+        assert actual.width == expected.width
+        assert actual.height == expected.height
+        comparison = compare_pixels(expected, actual)
+        self.assertGreaterEqual(comparison, self.threshold)
+
+    def test_resize_integrity_larger_noscaleup_height_only(self):
+        test_image = Image.open(self.img_dir / "seagull.jpg")
+        test_image.info["filename"] = "seagull.jpg"
+        query = {"resize": "x992,no-scale-up"}
+        expected = Image.open(self.img_dir / "seagull.jpg")
+        actual = process_transforms(test_image, query)
+        assert actual.width == expected.width
+        assert actual.height == expected.height
         comparison = compare_pixels(expected, actual)
         self.assertGreaterEqual(comparison, self.threshold)
 

--- a/its/transformations/resize.py
+++ b/its/transformations/resize.py
@@ -21,8 +21,11 @@ class ResizeTransform(BaseTransform):
         """
         Resizes input image while maintaining aspect ratio.
         """
+        option = ''
         if len(parameters) == 2:
             width, height = parameters
+        elif len(parameters) == 3:
+            width, height, option = parameters
         else:
             raise ITSClientError(
                 "Missing width or height. Both width and height are required"
@@ -69,6 +72,13 @@ class ResizeTransform(BaseTransform):
             # make sure target is at least one pixel wide
             tgt_width = max(floor(img.width * ratio), 1)
             tgt_height = max(floor(img.height * ratio), 1)
+
+        if option == 'no-scale-up' and (
+                tgt_width > img.width or
+                tgt_height > img.height
+            ):
+            tgt_height = img.height
+            tgt_width = img.width
 
         resized = img.resize([tgt_width, tgt_height], Image.ANTIALIAS)
 

--- a/its/transformations/resize.py
+++ b/its/transformations/resize.py
@@ -21,7 +21,7 @@ class ResizeTransform(BaseTransform):
         """
         Resizes input image while maintaining aspect ratio.
         """
-        option = ''
+        option = ""
         if len(parameters) == 2:
             width, height = parameters
         elif len(parameters) == 3:
@@ -73,10 +73,9 @@ class ResizeTransform(BaseTransform):
             tgt_width = max(floor(img.width * ratio), 1)
             tgt_height = max(floor(img.height * ratio), 1)
 
-        if option == 'no-scale-up' and (
-                tgt_width > img.width or
-                tgt_height > img.height
-            ):
+        if option == "no-scale-up" and (
+            tgt_width > img.width or tgt_height > img.height
+        ):
             tgt_height = img.height
             tgt_width = img.width
 


### PR DESCRIPTION
While using ITS, we noticed that for images that are very small (e.g. logos), requests with ?resize=<width>x scales up to <width> even if image width is smaller.

We'd like to add a parameter to resize (e.g. resize=100x,no-scale-up) to not apply the resize transformation if image width is smaller than the width sent as query parameter.

To that effect, this PR ads a no-scale-up option to resize, with as little change in code as possible.
Please let me know if I should change the implementation in any way.
Thank you